### PR TITLE
add snippet to create python header

### DIFF
--- a/snippets/python.cson
+++ b/snippets/python.cson
@@ -11,3 +11,19 @@
      import pdb
      pdb.set_trace()
     """
+  'create new file header':
+    'prefix': 'header'
+    'body': """#!/usr/bin/env python
+            # * coding: utf8 *
+            '''
+            ${1:module}.py
+
+            ${2:A module that contains}
+            '''
+
+            ${3:import }
+
+
+            ${4}
+
+            """

--- a/snippets/text.cson
+++ b/snippets/text.cson
@@ -1,0 +1,17 @@
+  '.text.plain':
+    'create new file header':
+      'prefix': 'header'
+      'body': """#!/usr/bin/env python
+              # * coding: utf8 *
+              '''
+              ${1:module}.py
+
+              ${2:A module that contains}
+              '''
+
+              ${3:import }
+
+
+              ${4}
+
+              """


### PR DESCRIPTION
Had to add plain text duplicate version so new file could work and you
didn't have to save the file as .py first.
